### PR TITLE
Fixed casting exception in PerformMigrationHandler.java

### DIFF
--- a/process-migration/src/main/java/org/jbpm/process/migration/handler/PerformMigrationHandler.java
+++ b/process-migration/src/main/java/org/jbpm/process/migration/handler/PerformMigrationHandler.java
@@ -17,14 +17,16 @@ public class PerformMigrationHandler implements WorkItemHandler {
 	@SuppressWarnings("unchecked")
 	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
 		ProcessData data = (ProcessData) workItem.getParameter("in_processdata");
-		List<NodeMapping> nodeMapping = new ArrayList<NodeMapping>();
+		//commented as we are directly getting List<NodeMapping> itself from the Human Task form
+		/*List<NodeMapping> nodeMapping = new ArrayList<NodeMapping>();
 		Map<String, String>[] inNodeMapping = (Map<String, String>[]) workItem.getParameter("in_nodemapping");
 		if (inNodeMapping != null) {
 			for (Map<String, String> inputMapping : inNodeMapping) {
 				nodeMapping.add(new NodeMapping(inputMapping.get("nodemap_sourceNodeId"), inputMapping.get("nodemap_targetNodeId")));
 			}
-		}
-
+		}*/
+		
+		List<NodeMapping> nodeMapping = (List<NodeMapping>) workItem.getParameter("in_nodemapping");
 		String outcome = MigrationManager.migrate(data, nodeMapping);
 		
 		Map<String, Object> results = new HashMap<String, Object>();


### PR DESCRIPTION
java.util.ArrayList cannot be cast to [Ljava.util.Map at workItem.getParameter("in_nodemapping");  
as we are directly getting List<NodeMapping> instead of Map*